### PR TITLE
Update to Quarkus 1.6

### DIFF
--- a/embedded/deployment/src/main/java/org/infinispan/quarkus/embedded/deployment/InfinispanEmbeddedProcessor.java
+++ b/embedded/deployment/src/main/java/org/infinispan/quarkus/embedded/deployment/InfinispanEmbeddedProcessor.java
@@ -73,7 +73,7 @@ class InfinispanEmbeddedProcessor {
             BuildProducer<NativeImageResourceBuildItem> resources, CombinedIndexBuildItem combinedIndexBuildItem,
             List<InfinispanReflectionExcludedBuildItem> excludedReflectionClasses,
             ApplicationIndexBuildItem applicationIndexBuildItem, BuildProducer<NativeImageResourceBundleBuildItem> bundles) {
-        feature.produce(new FeatureBuildItem(FeatureBuildItem.INFINISPAN_EMBEDDED));
+        feature.produce(new FeatureBuildItem("infinispan-embedded"));
 
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(InfinispanEmbeddedProducer.class));
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>1.5.0.Final</quarkus.version>
+        <quarkus.version>1.6.0.Final</quarkus.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Closes #17 

I couldn't get it to build (`mvn clean install -DskipTests`), but hopefully CI knows how to get it right:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.1.1:copy (copy-runner) on project infinispan-quarkus-integration-test-server: Unable to find/resolve artifact.: Could not find artifact org.infinispan:infinispan-quarkus-server-runner:bin:11.0.2-SNAPSHOT -> [Help 1]
```