### PR TITLE
[11.x] Upgrade to Quarkus 1.7 (after 1.6 and 1.6.1) and fix the MBean server issues

### DIFF
--- a/embedded/deployment/pom.xml
+++ b/embedded/deployment/pom.xml
@@ -17,7 +17,7 @@
         <dependencies>
             <dependency>
                 <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-quarkus-bom-deployment</artifactId>
+                <artifactId>infinispan-quarkus-bom</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/embedded/deployment/pom.xml
+++ b/embedded/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-quarkus-embedded-parent</artifactId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/embedded/deployment/src/main/java/org/infinispan/quarkus/embedded/deployment/InfinispanEmbeddedProcessor.java
+++ b/embedded/deployment/src/main/java/org/infinispan/quarkus/embedded/deployment/InfinispanEmbeddedProcessor.java
@@ -73,7 +73,7 @@ class InfinispanEmbeddedProcessor {
             BuildProducer<NativeImageResourceBuildItem> resources, CombinedIndexBuildItem combinedIndexBuildItem,
             List<InfinispanReflectionExcludedBuildItem> excludedReflectionClasses,
             ApplicationIndexBuildItem applicationIndexBuildItem, BuildProducer<NativeImageResourceBundleBuildItem> bundles) {
-        feature.produce(new FeatureBuildItem(FeatureBuildItem.INFINISPAN_EMBEDDED));
+        feature.produce(new FeatureBuildItem("infinispan-embedded"));
 
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(InfinispanEmbeddedProducer.class));
 

--- a/embedded/pom.xml
+++ b/embedded/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-quarkus-parent</artifactId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>infinispan-quarkus-embedded-parent</artifactId>
-    <version>11.0.4-SNAPSHOT</version>
+    <version>11.0.5-SNAPSHOT</version>
     <name>Infinispan - Quarkus - Embedded - Parent</name>
 
     <packaging>pom</packaging>

--- a/embedded/runtime/pom.xml
+++ b/embedded/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-quarkus-embedded-parent</artifactId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/embedded/pom.xml
+++ b/integration-tests/embedded/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>infinispan-quarkus-integration-tests-parent</artifactId>
         <groupId>org.infinispan</groupId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>infinispan-quarkus-parent</artifactId>
         <groupId>org.infinispan</groupId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/integration-tests/server/pom.xml
+++ b/integration-tests/server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-quarkus-integration-tests-parent</artifactId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>infinispan-quarkus-integration-test-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>1.6.1.Final</quarkus.version>
+        <quarkus.version>1.7.0.Final</quarkus.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>1.6.0.Final</quarkus.version>
+        <quarkus.version>1.6.1.Final</quarkus.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>1.5.0.Final</quarkus.version>
+        <quarkus.version>1.6.0.Final</quarkus.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.infinispan</groupId>
     <artifactId>infinispan-quarkus-parent</artifactId>
-    <version>11.0.4-SNAPSHOT</version>
+    <version>11.0.5-SNAPSHOT</version>
     <name>Infinispan Quarkus - Parent pom</name>
     <packaging>pom</packaging>
 

--- a/poms/bom-deployment/pom.xml
+++ b/poms/bom-deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-quarkus-poms</artifactId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/poms/bom-deployment/pom.xml
+++ b/poms/bom-deployment/pom.xml
@@ -29,7 +29,7 @@
             <!-- External BOMs -->
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom-deployment</artifactId>
+                <artifactId>quarkus-bom</artifactId>
                 <version>${quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/poms/bom-test/pom.xml
+++ b/poms/bom-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-quarkus-poms</artifactId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-quarkus-poms</artifactId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-quarkus-parent</artifactId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/server-runner/pom.xml
+++ b/server-runner/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-quarkus-parent</artifactId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/deployment/pom.xml
+++ b/server/deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-quarkus-server-parent</artifactId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-quarkus-parent</artifactId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>infinispan-quarkus-server-parent</artifactId>
-    <version>11.0.4-SNAPSHOT</version>
+    <version>11.0.5-SNAPSHOT</version>
     <name>Infinispan - Quarkus - Server - Parent</name>
 
     <packaging>pom</packaging>

--- a/server/runtime/pom.xml
+++ b/server/runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-quarkus-server-parent</artifactId>
-        <version>11.0.4-SNAPSHOT</version>
+        <version>11.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server/runtime/src/main/java/org/infinispan/quarkus/server/runtime/graal/SubstituteClientClasses.java
+++ b/server/runtime/src/main/java/org/infinispan/quarkus/server/runtime/graal/SubstituteClientClasses.java
@@ -1,0 +1,83 @@
+package org.infinispan.quarkus.server.runtime.graal;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Delete;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.impl.InternalRemoteCache;
+import org.infinispan.client.hotrod.impl.RemoteCacheImpl;
+import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
+import org.infinispan.commons.marshall.Marshaller;
+
+import javax.management.ObjectName;
+import java.util.concurrent.ExecutorService;
+
+@Substitute
+@TargetClass(className = "org.infinispan.client.hotrod.impl.transport.netty.TransportHelper")
+final class SubstituteTransportHelper {
+
+    @Substitute
+    static Class<? extends SocketChannel> socketChannel() {
+        return NioSocketChannel.class;
+    }
+
+    @Substitute
+    static EventLoopGroup createEventLoopGroup(int maxExecutors, ExecutorService executorService) {
+        return new NioEventLoopGroup(maxExecutors, executorService);
+    }
+}
+
+@TargetClass(RemoteCacheManager.class)
+final class SubstituteRemoteCacheManager {
+    @Alias
+    private Marshaller marshaller;
+    @Alias
+    private Configuration configuration;
+
+    @Substitute
+    private void initRemoteCache(InternalRemoteCache<?, ?> remoteCache, OperationsFactory operationsFactory) {
+        // Invoke the init method that doesn't have the JMX ObjectName argument
+        remoteCache.init(marshaller, operationsFactory, configuration);
+    }
+
+    @Substitute
+    private void registerMBean() {
+    }
+
+    @Substitute
+    private void unregisterMBean() {
+
+    }
+}
+
+@TargetClass(RemoteCacheImpl.class)
+final class SubstituteRemoteCacheImpl {
+    @Delete
+    private ObjectName mbeanObjectName;
+
+    @Substitute
+    private void registerMBean(ObjectName jmxParent) {
+    }
+
+    @Substitute
+    private void unregisterMBean() {
+    }
+
+    // Sadly this method is public, so technically a user could get a Runtime error if they were referencing
+    // it before - but it is the only way to make graal happy
+    @Delete
+    public void init(Marshaller marshaller, OperationsFactory operationsFactory,
+                     Configuration configuration, ObjectName jmxParent) {
+    }
+}
+
+// TODO sort out duplication with quarkus infinispan-client extension
+public class SubstituteClientClasses {
+}
+

--- a/server/runtime/src/main/java/org/infinispan/quarkus/server/runtime/graal/SubstituteLog4jClasses.java
+++ b/server/runtime/src/main/java/org/infinispan/quarkus/server/runtime/graal/SubstituteLog4jClasses.java
@@ -1,0 +1,29 @@
+package org.infinispan.quarkus.server.runtime.graal;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.apache.logging.log4j.core.jmx.Server;
+
+@TargetClass(Server.class)
+final class SubstituteJmxServer {
+
+    @Substitute
+    public static void unregisterLoggerContext(final String loggerContextName) {
+        // No-op
+    }
+
+    @Substitute
+    public static void reregisterMBeansAfterReconfigure() {
+        // No-op
+    }
+
+    @Substitute
+    public static void unregisterMBeans() {
+        // No-op
+    }
+
+}
+
+public class SubstituteLog4jClasses
+{
+}

--- a/server/runtime/src/main/java/org/infinispan/quarkus/server/runtime/graal/SubstituteMetrics.java
+++ b/server/runtime/src/main/java/org/infinispan/quarkus/server/runtime/graal/SubstituteMetrics.java
@@ -1,0 +1,19 @@
+package org.infinispan.quarkus.server.runtime.graal;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.infinispan.rest.resources.MetricsResource;
+
+@TargetClass(MetricsResource.class)
+final class SubstituteMetricsResource {
+
+    @Substitute
+    private void registerBaseMetrics() {
+        // No-op
+    }
+
+}
+
+public class SubstituteMetrics
+{
+}

--- a/server/runtime/src/main/java/org/infinispan/quarkus/server/runtime/graal/SubstituteNettyClasses.java
+++ b/server/runtime/src/main/java/org/infinispan/quarkus/server/runtime/graal/SubstituteNettyClasses.java
@@ -51,18 +51,3 @@ final class Substitute_NettyTransport {
 @Delete
 @TargetClass(className = "org.infinispan.server.core.transport.EPollAvailable")
 final class Delete_org_infinispan_client_hotrod_impl_transport_netty_EPollAvailable { }
-
-@Substitute
-@TargetClass(className = "org.infinispan.client.hotrod.impl.transport.netty.TransportHelper")
-final class SubstituteTransportHelper {
-
-   @Substitute
-   static Class<? extends SocketChannel> socketChannel() {
-      return NioSocketChannel.class;
-   }
-
-   @Substitute
-   static EventLoopGroup createEventLoopGroup(int maxExecutors, ExecutorService executorService) {
-      return new NioEventLoopGroup(maxExecutors, executorService);
-   }
-}


### PR DESCRIPTION
This is all to make Infinispan native server buildable with GraalVM 20.2. Let's see what CI says about that :)