### PR TITLE
Fixes for native profiles and java invocations

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -84,7 +84,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>java</executable>
+                            <executable>${env.JAVA_HOME}/bin/java</executable>
                             <workingDirectory>target</workingDirectory>
                             <arguments>
                                 <argument>-cp</argument>
@@ -101,7 +101,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>java</executable>
+                            <executable>${env.JAVA_HOME}/bin/java</executable>
                             <workingDirectory>target</workingDirectory>
                             <arguments>
                                 <argument>-cp</argument>

--- a/server-runner/pom.xml
+++ b/server-runner/pom.xml
@@ -169,5 +169,67 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>native-noargs</id>
+            <activation>
+                <property>
+                    <name>native-noargs</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${quarkus.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-artifacts</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${project.build.directory}/${project.build.finalName}-runner</file>
+                                            <type>bin</type>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Closes #26 and #38 

For #26, added an extra profile called `native-noargs` to make it easy to build native along with command line provided options. Example usages are:

* Debugging closed world analysis: `-Dquarkus.native.additional-build-args=-H:+PrintAnalysisCallTree`
* Step-by-step debugging of native executable production: `-Dquarkus.native.additional-build-args=--debug-attach=8000`
* Profiling: `-Dquarkus.native.additional-build-args=-H:-DeleteLocalSymbols,-H:+PreserveFramePointer`

As it stands, any uses of `-Dnative-noargs` would also require adding `--allow-incomplete-classpath` to the examples above, e.g. `-Dquarkus.native.additional-build-args=-H:+PrintAnalysisCallTree,--allow-incomplete-classpath`.

For #38, made sure that `java` invocations are relative to `JAVA_HOME`.