### PR TITLE
Master fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>1.8.3.Final</quarkus.version>
+        <quarkus.version>1.10.5.Final</quarkus.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>1.10.5.Final</quarkus.version>
+        <quarkus.version>1.11.0.Final</quarkus.version>
     </properties>
 
     <modules>

--- a/poms/bom-test/pom.xml
+++ b/poms/bom-test/pom.xml
@@ -27,6 +27,13 @@
 
             <dependency>
                 <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-core</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-commons-test</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -17,7 +17,7 @@
     <name>Infinispan Quarkus :: BOM</name>
 
     <properties>
-      <infinispan.version>${project.version}</infinispan.version>
+      <elytron.version>1.13.2.Final</elytron.version>
     </properties>
 
     <dependencyManagement>
@@ -71,6 +71,12 @@
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-quarkus-server-runner</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron</artifactId>
+                <version>${elytron.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/server/deployment/src/main/java/org/infinispan/quarkus/server/deployment/InfinispanServerProcessor.java
+++ b/server/deployment/src/main/java/org/infinispan/quarkus/server/deployment/InfinispanServerProcessor.java
@@ -197,7 +197,11 @@ class InfinispanServerProcessor {
             "org.wildfly.security.sasl.plain.PlainSaslClientFactory",
             "org.wildfly.security.sasl.plain.PlainSaslServerFactory",
             "org.wildfly.security.sasl.scram.ScramSaslClientFactory",
-            "org.wildfly.security.sasl.scram.ScramSaslServerFactory"
+            "org.wildfly.security.sasl.scram.ScramSaslServerFactory",
+            "org.wildfly.security.credential.KeyPairCredential",
+            "org.wildfly.security.credential.PasswordCredential",
+            "org.wildfly.security.credential.SecretKeyCredential",
+            "org.wildfly.security.credential.X509CertificateChainPrivateCredential",
       };
       reflectionClass.produce(new ReflectiveClassBuildItem(true, false, elytronClasses));
 

--- a/server/deployment/src/main/java/org/infinispan/quarkus/server/deployment/InfinispanServerProcessor.java
+++ b/server/deployment/src/main/java/org/infinispan/quarkus/server/deployment/InfinispanServerProcessor.java
@@ -12,7 +12,6 @@ import org.infinispan.anchored.configuration.AnchoredKeysConfigurationBuilder;
 import org.infinispan.commands.module.ModuleCommandExtensions;
 import org.infinispan.commons.util.JVMMemoryInfoInfo;
 import org.infinispan.configuration.internal.PrivateGlobalConfigurationBuilder;
-import org.infinispan.lock.configuration.ClusteredLockConfigurationBuilder;
 import org.infinispan.lock.configuration.ClusteredLockManagerConfigurationBuilder;
 import org.infinispan.manager.CacheManagerInfo;
 import org.infinispan.protostream.WrappedMessage;
@@ -32,7 +31,6 @@ import org.jboss.jandex.IndexView;
 import org.jgroups.protocols.SASL;
 import org.wildfly.security.password.impl.PasswordFactorySpiImpl;
 
-import com.sun.jndi.dns.DnsClient;
 import com.thoughtworks.xstream.security.NoTypePermission;
 
 import io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler;
@@ -51,7 +49,6 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 
 class InfinispanServerProcessor {

--- a/server/runtime/src/main/java/org/infinispan/quarkus/server/runtime/graal/FixModuleClasses.java
+++ b/server/runtime/src/main/java/org/infinispan/quarkus/server/runtime/graal/FixModuleClasses.java
@@ -4,6 +4,7 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
+import org.infinispan.server.configuration.ServerConfigurationBuilder;
 import org.infinispan.server.configuration.ServerConfigurationParser;
 import org.infinispan.server.configuration.security.LdapRealmConfigurationBuilder;
 import org.infinispan.server.configuration.security.TrustStoreRealmConfigurationBuilder;
@@ -27,7 +28,7 @@ final class Target_ServerConfigurationParser {
    private static Log coreLog;
 
    @Substitute
-   private void parseLdapRealm(XMLExtendedStreamReader reader, LdapRealmConfigurationBuilder ldapRealmConfigBuilder) throws XMLStreamException {
+   private void parseLdapRealm(XMLExtendedStreamReader reader, ServerConfigurationBuilder builder, LdapRealmConfigurationBuilder ldapRealmConfigBuilder) throws XMLStreamException {
       coreLog.debug("LDAP Realm is not supported in native mode - ignoring element");
       // Just read until end of token
       while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
@@ -36,7 +37,7 @@ final class Target_ServerConfigurationParser {
    }
 
    @Substitute
-   private void parseTrustStoreRealm(XMLExtendedStreamReader reader, TrustStoreRealmConfigurationBuilder trustStoreBuilder) throws XMLStreamException {
+   private void parseTrustStoreRealm(XMLExtendedStreamReader reader, ServerConfigurationBuilder builder, TrustStoreRealmConfigurationBuilder trustStoreBuilder) throws XMLStreamException {
       coreLog.debug("TrustStore Realm is not supported in native mode - ignoring element");
       // Just read until end of token
       while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {

--- a/server/runtime/src/main/java/org/infinispan/quarkus/server/runtime/graal/SubstituteElytronClasses.java
+++ b/server/runtime/src/main/java/org/infinispan/quarkus/server/runtime/graal/SubstituteElytronClasses.java
@@ -1,0 +1,83 @@
+package org.infinispan.quarkus.server.runtime.graal;
+
+import static java.security.AccessController.doPrivileged;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.security.Key;
+import java.security.PrivilegedAction;
+import java.util.function.UnaryOperator;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+public class SubstituteElytronClasses {
+}
+
+@TargetClass(className = "org.wildfly.security.key.KeyUtil$KeyClonerCreator")
+final class Target_org_wildfly_security_key_KeyUtil_KeyClonerCreator {
+   @Substitute
+   private UnaryOperator<Key> checkForCloneMethod(final Class<?> declType, final Class<?> returnType) {
+      final Method method = doPrivileged(new PrivilegedAction<Method>() {
+         @Override
+         public Method run() {
+            try {
+               Method cloneMethod = declType.getDeclaredMethod("clone");
+               if (cloneMethod.getReturnType() == returnType)
+                  return cloneMethod;
+
+               return null;
+            } catch (NoSuchMethodException e) {
+               return null;
+            }
+         }
+      });
+
+      if (method == null)
+         return null;
+
+      return new UnaryOperator<Key>() {
+         @Override
+         public Key apply(Key key) {
+            try {
+               return (Key) method.invoke(key);
+            } catch (RuntimeException | Error e) {
+               throw e;
+            } catch (Throwable throwable) {
+               throw new UndeclaredThrowableException(throwable);
+            }
+         }
+      };
+   }
+
+   @Substitute
+   private UnaryOperator<Key> checkForCopyCtor(final Class<?> declType, final Class<?> paramType) {
+      final Constructor<?> constructor = doPrivileged(new PrivilegedAction<Constructor<?>>() {
+         @Override
+         public Constructor<?> run() {
+            try {
+               return declType.getDeclaredConstructor(paramType);
+            } catch (NoSuchMethodException e) {
+               return null;
+            }
+         }
+      });
+
+      if (constructor == null)
+         return null;
+
+      return new UnaryOperator<Key>() {
+         @Override
+         public Key apply(Key key) {
+            try {
+               return (Key) constructor.newInstance(key);
+            } catch (RuntimeException | Error e) {
+               throw e;
+            } catch (Throwable throwable) {
+               throw new UndeclaredThrowableException(throwable);
+            }
+         }
+      };
+   }
+}


### PR DESCRIPTION
@wburns This fixes a compilation issue with the latest Infinispan master, however I'm now getting the following:

```
[INFO] --- quarkus-maven-plugin:1.8.3.Final:native-image (default) @ infinispan-quarkus-server-runner ---
[INFO] [io.quarkus.deployment.pkg.steps.JarResultBuildStep] Building native image source jar: /home/remerson/workspace/RedHat/infinispan/infinispan-quarkus/server-runner/target/infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-native-image-source-jar/infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-runner.jar
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Building native image from /home/remerson/workspace/RedHat/infinispan/infinispan-quarkus/server-runner/target/infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-native-image-source-jar/infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-runner.jar
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on GraalVM Version 20.2.0 (Java Version 11.0.8)
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] /home/remerson/Programs/graalvm-ce-java11-20.2.0/bin/native-image -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=1 -J-Dsubstratevm.replacement.jdksslcontext=false -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Duser.language=en -J-Dfile.encoding=UTF-8 --allow-incomplete-classpath --initialize-at-build-time= -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy\$BySpaceAndTime -H:+JNI -jar infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-runner.jar -H:FallbackThreshold=0 -H:+ReportExceptionStackTraces -H:-AddAllCharsets -H:EnableURLProtocols=http,https --enable-all-security-services -H:NativeLinkerOption=-no-pie --no-server -H:-UseServiceLoaderFeature -H:+StackTrace infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-runner
[infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-runner:189139]    classlist:  10,277.39 ms,  1.18 GB
[infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-runner:189139]        (cap):     675.04 ms,  1.18 GB
[infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-runner:189139]        setup:   2,355.35 ms,  1.18 GB
17:56:42,577 INFO  [org.jbo.threads] JBoss Threads version 3.1.1.Final
17:56:44,941 INFO  [org.wil.ope.SSL] WFOPENSSL0002 OpenSSL Version OpenSSL 1.1.1g FIPS  21 Apr 2020
17:56:44,943 INFO  [org.inf.SECURITY] ISPN000946: Using OpenSSL Provider
17:56:46,309 INFO  [org.hib.ann.com.Version] HCANN000001: Hibernate Commons Annotations {5.1.2.Final}
17:56:50,966 INFO  [org.wil.security] ELY00001: WildFly Elytron version 1.12.1.Final
[infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-runner:189139]     (clinit):   1,058.24 ms,  5.33 GB
[infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-runner:189139]   (typeflow):  29,214.03 ms,  5.33 GB
[infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-runner:189139]    (objects):  26,919.51 ms,  5.33 GB
[infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-runner:189139]   (features):   1,666.48 ms,  5.33 GB
[infinispan-quarkus-server-runner-12.0.0-SNAPSHOT-runner:189139]     analysis:  62,562.08 ms,  5.33 GB
Error: Unsupported features in 3 methods
Detailed message:
Error: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Invoke with MethodHandle argument could not be reduced to at most a single call or single field access. The method handle must be a compile time constant, e.g., be loaded from a `static final` field. Method that contains the method handle invocation: java.lang.invoke.MethodHandle.invokeBasic(Object)
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The error is then reported at run time when the invoke is executed.
Trace: 
	at parsing java.lang.invoke.LambdaForm$MH/0x00000007c27e7440.invoke_MT(LambdaForm$MH)
Call path from entry point to java.lang.invoke.LambdaForm$MH/89291973.invoke_MT(Object, Object, Object): 
	at java.lang.invoke.LambdaForm$MH/0x00000007c27e7440.invoke_MT(LambdaForm$MH)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator.lambda$produceOp$4(KeyUtil.java:368)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator$$Lambda$4000/0x00000007c1ee6c40.apply(Unknown Source)
	at sun.security.ec.XECParameters$1.get(XECParameters.java:183)
	at com.oracle.svm.core.jdk.SystemPropertiesSupport.initializeLazyValue(SystemPropertiesSupport.java:190)
	at com.oracle.svm.core.jdk.SystemPropertiesSupport.getProperty(SystemPropertiesSupport.java:143)
	at com.oracle.svm.core.jdk.Target_java_lang_System.getProperty(JavaLangSubstitutions.java:331)
	at com.oracle.svm.jni.JNIJavaCallWrappers.jniInvoke_VARARGS:Ljava_lang_System_2_0002egetProperty_00028Ljava_lang_String_2_00029Ljava_lang_String_2(generated:0)
Error: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported type java.lang.invoke.MemberName is reachable: All methods from java.lang.invoke should have been replaced during image building.
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The unsupported element is then reported at run time when it is accessed the first time.
Trace: 
	at parsing java.lang.invoke.MethodHandles$Lookup.findConstructor(MethodHandles.java:1264)
Call path from entry point to java.lang.invoke.MethodHandles$Lookup.findConstructor(Class, MethodType): 
	at java.lang.invoke.MethodHandles$Lookup.findConstructor(MethodHandles.java:1260)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator.lambda$checkForCopyCtor$3(KeyUtil.java:357)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator$$Lambda$4001/0x00000007c1ee6840.run(Unknown Source)
	at com.oracle.svm.core.jdk.Target_java_security_AccessController.doPrivileged(SecuritySubstitutions.java:83)
	at sun.security.pkcs11.SunPKCS11.initToken(SunPKCS11.java:1028)
	at sun.security.pkcs11.SunPKCS11$TokenPoller.run(SunPKCS11.java:852)
	at java.lang.Thread.run(Thread.java:834)
	at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:517)
	at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:192)
	at com.oracle.svm.core.code.IsolateEnterStub.PosixJavaThreads_pthreadStartRoutine_e1f4a8c0039f8337338252cd8734f63a79b5e3df(generated:0)
Error: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported type java.lang.invoke.MemberName is reachable: All methods from java.lang.invoke should have been replaced during image building.
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The unsupported element is then reported at run time when it is accessed the first time.
Trace: 
	at parsing java.lang.invoke.MethodHandles$Lookup.findVirtual(MethodHandles.java:1194)
Call path from entry point to java.lang.invoke.MethodHandles$Lookup.findVirtual(Class, String, MethodType): 
	at java.lang.invoke.MethodHandles$Lookup.findVirtual(MethodHandles.java:1186)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator.lambda$checkForCloneMethod$2(KeyUtil.java:345)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator$$Lambda$3999/0x00000007c1ee7440.run(Unknown Source)
	at com.oracle.svm.core.jdk.Target_java_security_AccessController.doPrivileged(SecuritySubstitutions.java:83)
	at sun.security.pkcs11.SunPKCS11.initToken(SunPKCS11.java:1028)
	at sun.security.pkcs11.SunPKCS11$TokenPoller.run(SunPKCS11.java:852)
	at java.lang.Thread.run(Thread.java:834)
	at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:517)
	at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:192)
	at com.oracle.svm.core.code.IsolateEnterStub.PosixJavaThreads_pthreadStartRoutine_e1f4a8c0039f8337338252cd8734f63a79b5e3df(generated:0)

com.oracle.svm.core.util.UserError$UserException: Unsupported features in 3 methods
Detailed message:
Error: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Invoke with MethodHandle argument could not be reduced to at most a single call or single field access. The method handle must be a compile time constant, e.g., be loaded from a `static final` field. Method that contains the method handle invocation: java.lang.invoke.MethodHandle.invokeBasic(Object)
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The error is then reported at run time when the invoke is executed.
Trace: 
	at parsing java.lang.invoke.LambdaForm$MH/0x00000007c27e7440.invoke_MT(LambdaForm$MH)
Call path from entry point to java.lang.invoke.LambdaForm$MH/89291973.invoke_MT(Object, Object, Object): 
	at java.lang.invoke.LambdaForm$MH/0x00000007c27e7440.invoke_MT(LambdaForm$MH)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator.lambda$produceOp$4(KeyUtil.java:368)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator$$Lambda$4000/0x00000007c1ee6c40.apply(Unknown Source)
	at sun.security.ec.XECParameters$1.get(XECParameters.java:183)
	at com.oracle.svm.core.jdk.SystemPropertiesSupport.initializeLazyValue(SystemPropertiesSupport.java:190)
	at com.oracle.svm.core.jdk.SystemPropertiesSupport.getProperty(SystemPropertiesSupport.java:143)
	at com.oracle.svm.core.jdk.Target_java_lang_System.getProperty(JavaLangSubstitutions.java:331)
	at com.oracle.svm.jni.JNIJavaCallWrappers.jniInvoke_VARARGS:Ljava_lang_System_2_0002egetProperty_00028Ljava_lang_String_2_00029Ljava_lang_String_2(generated:0)
Error: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported type java.lang.invoke.MemberName is reachable: All methods from java.lang.invoke should have been replaced during image building.
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The unsupported element is then reported at run time when it is accessed the first time.
Trace: 
	at parsing java.lang.invoke.MethodHandles$Lookup.findConstructor(MethodHandles.java:1264)
Call path from entry point to java.lang.invoke.MethodHandles$Lookup.findConstructor(Class, MethodType): 
	at java.lang.invoke.MethodHandles$Lookup.findConstructor(MethodHandles.java:1260)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator.lambda$checkForCopyCtor$3(KeyUtil.java:357)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator$$Lambda$4001/0x00000007c1ee6840.run(Unknown Source)
	at com.oracle.svm.core.jdk.Target_java_security_AccessController.doPrivileged(SecuritySubstitutions.java:83)
	at sun.security.pkcs11.SunPKCS11.initToken(SunPKCS11.java:1028)
	at sun.security.pkcs11.SunPKCS11$TokenPoller.run(SunPKCS11.java:852)
	at java.lang.Thread.run(Thread.java:834)
	at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:517)
	at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:192)
	at com.oracle.svm.core.code.IsolateEnterStub.PosixJavaThreads_pthreadStartRoutine_e1f4a8c0039f8337338252cd8734f63a79b5e3df(generated:0)
Error: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported type java.lang.invoke.MemberName is reachable: All methods from java.lang.invoke should have been replaced during image building.
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The unsupported element is then reported at run time when it is accessed the first time.
Trace: 
	at parsing java.lang.invoke.MethodHandles$Lookup.findVirtual(MethodHandles.java:1194)
Call path from entry point to java.lang.invoke.MethodHandles$Lookup.findVirtual(Class, String, MethodType): 
	at java.lang.invoke.MethodHandles$Lookup.findVirtual(MethodHandles.java:1186)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator.lambda$checkForCloneMethod$2(KeyUtil.java:345)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator$$Lambda$3999/0x00000007c1ee7440.run(Unknown Source)
	at com.oracle.svm.core.jdk.Target_java_security_AccessController.doPrivileged(SecuritySubstitutions.java:83)
	at sun.security.pkcs11.SunPKCS11.initToken(SunPKCS11.java:1028)
	at sun.security.pkcs11.SunPKCS11$TokenPoller.run(SunPKCS11.java:852)
	at java.lang.Thread.run(Thread.java:834)
	at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:517)
	at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:192)
	at com.oracle.svm.core.code.IsolateEnterStub.PosixJavaThreads_pthreadStartRoutine_e1f4a8c0039f8337338252cd8734f63a79b5e3df(generated:0)

	at com.oracle.svm.core.util.UserError.abort(UserError.java:79)
	at com.oracle.svm.hosted.FallbackFeature.reportAsFallback(FallbackFeature.java:217)
	at com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:765)
	at com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:555)
	at com.oracle.svm.hosted.NativeImageGenerator.lambda$run$0(NativeImageGenerator.java:468)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1407)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Unsupported features in 3 methods
Detailed message:
Error: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Invoke with MethodHandle argument could not be reduced to at most a single call or single field access. The method handle must be a compile time constant, e.g., be loaded from a `static final` field. Method that contains the method handle invocation: java.lang.invoke.MethodHandle.invokeBasic(Object)
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The error is then reported at run time when the invoke is executed.
Trace: 
	at parsing java.lang.invoke.LambdaForm$MH/0x00000007c27e7440.invoke_MT(LambdaForm$MH)
Call path from entry point to java.lang.invoke.LambdaForm$MH/89291973.invoke_MT(Object, Object, Object): 
	at java.lang.invoke.LambdaForm$MH/0x00000007c27e7440.invoke_MT(LambdaForm$MH)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator.lambda$produceOp$4(KeyUtil.java:368)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator$$Lambda$4000/0x00000007c1ee6c40.apply(Unknown Source)
	at sun.security.ec.XECParameters$1.get(XECParameters.java:183)
	at com.oracle.svm.core.jdk.SystemPropertiesSupport.initializeLazyValue(SystemPropertiesSupport.java:190)
	at com.oracle.svm.core.jdk.SystemPropertiesSupport.getProperty(SystemPropertiesSupport.java:143)
	at com.oracle.svm.core.jdk.Target_java_lang_System.getProperty(JavaLangSubstitutions.java:331)
	at com.oracle.svm.jni.JNIJavaCallWrappers.jniInvoke_VARARGS:Ljava_lang_System_2_0002egetProperty_00028Ljava_lang_String_2_00029Ljava_lang_String_2(generated:0)
Error: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported type java.lang.invoke.MemberName is reachable: All methods from java.lang.invoke should have been replaced during image building.
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The unsupported element is then reported at run time when it is accessed the first time.
Trace: 
	at parsing java.lang.invoke.MethodHandles$Lookup.findConstructor(MethodHandles.java:1264)
Call path from entry point to java.lang.invoke.MethodHandles$Lookup.findConstructor(Class, MethodType): 
	at java.lang.invoke.MethodHandles$Lookup.findConstructor(MethodHandles.java:1260)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator.lambda$checkForCopyCtor$3(KeyUtil.java:357)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator$$Lambda$4001/0x00000007c1ee6840.run(Unknown Source)
	at com.oracle.svm.core.jdk.Target_java_security_AccessController.doPrivileged(SecuritySubstitutions.java:83)
	at sun.security.pkcs11.SunPKCS11.initToken(SunPKCS11.java:1028)
	at sun.security.pkcs11.SunPKCS11$TokenPoller.run(SunPKCS11.java:852)
	at java.lang.Thread.run(Thread.java:834)
	at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:517)
	at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:192)
	at com.oracle.svm.core.code.IsolateEnterStub.PosixJavaThreads_pthreadStartRoutine_e1f4a8c0039f8337338252cd8734f63a79b5e3df(generated:0)
Error: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported type java.lang.invoke.MemberName is reachable: All methods from java.lang.invoke should have been replaced during image building.
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The unsupported element is then reported at run time when it is accessed the first time.
Trace: 
	at parsing java.lang.invoke.MethodHandles$Lookup.findVirtual(MethodHandles.java:1194)
Call path from entry point to java.lang.invoke.MethodHandles$Lookup.findVirtual(Class, String, MethodType): 
	at java.lang.invoke.MethodHandles$Lookup.findVirtual(MethodHandles.java:1186)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator.lambda$checkForCloneMethod$2(KeyUtil.java:345)
	at org.wildfly.security.key.KeyUtil$KeyClonerCreator$$Lambda$3999/0x00000007c1ee7440.run(Unknown Source)
	at com.oracle.svm.core.jdk.Target_java_security_AccessController.doPrivileged(SecuritySubstitutions.java:83)
	at sun.security.pkcs11.SunPKCS11.initToken(SunPKCS11.java:1028)
	at sun.security.pkcs11.SunPKCS11$TokenPoller.run(SunPKCS11.java:852)
	at java.lang.Thread.run(Thread.java:834)
	at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:517)
	at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:192)
	at com.oracle.svm.core.code.IsolateEnterStub.PosixJavaThreads_pthreadStartRoutine_e1f4a8c0039f8337338252cd8734f63a79b5e3df(generated:0)

	at com.oracle.graal.pointsto.constraints.UnsupportedFeatures.report(UnsupportedFeatures.java:129)
	at com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:762)
	... 8 more
Error: Image build request failed with exit status 1

```