### PR TITLE
[12.0.x] CLI fixes infinispan/infinispan-images#118

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         stage('Build') {
             steps {
                 // First we compile Infinispan SNAPSHOT
-                sh 'git clone --single-branch --branch master --depth 1 https://github.com/infinispan/infinispan.git'
+                sh 'git clone --single-branch --branch 12.0.x --depth 1 https://github.com/infinispan/infinispan.git'
                 dir('infinispan') {
                     sh '$MAVEN_HOME/bin/mvn clean install -DskipTests'
                     deleteDir()

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -111,6 +111,23 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>aesh-batch-native-reflection</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <workingDirectory>target</workingDirectory>
+                            <arguments>
+                                <argument>-cp</argument>
+                                <classpath/>
+                                <argument>org.infinispan.cli.util.aesh.graal.GraalReflectionFileGenerator</argument>
+                                <argument>org.infinispan.cli.commands.Batch</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -120,6 +137,28 @@
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemProperties>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/ispn-cli</file>
+                                    <type>bin</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -147,7 +186,7 @@
                                     <additionalBuildArgs>
                                         <additionalBuildArg>--allow-incomplete-classpath</additionalBuildArg>
                                         <additionalBuildArg>-H:ResourceConfigurationFiles=${project.basedir}/src/main/native/cli_resources.json</additionalBuildArg>
-                                        <additionalBuildArg>-H:ReflectionConfigurationFiles=${project.build.directory}/cli_reflection.json,${project.build.directory}/kube_reflection.json,${project.basedir}/src/main/native/cli.json</additionalBuildArg>
+                                        <additionalBuildArg>-H:ReflectionConfigurationFiles=${project.build.directory}/cli_reflection.json,${project.build.directory}/kube_reflection.json,${project.build.directory}/batch_reflection.json,${project.basedir}/src/main/native/cli.json</additionalBuildArg>
                                     </additionalBuildArgs>
                                 </configuration>
                             </execution>

--- a/cli/src/main/native/cli.json
+++ b/cli/src/main/native/cli.json
@@ -13,6 +13,10 @@
     ]
   },
   {
+    "name": "org.infinispan.cli.impl.ExitCodeResultHandler",
+    "allDeclaredConstructors": true
+  },
+  {
     "name": "org.apache.logging.log4j.message.DefaultFlowMessageFactory",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true

--- a/integration-tests/server/pom.xml
+++ b/integration-tests/server/pom.xml
@@ -32,6 +32,10 @@
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-quarkus-cli</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
             <artifactId>infinispan-quarkus-server-runner</artifactId>
         </dependency>
         <dependency>
@@ -83,7 +87,37 @@
                                     <outputDirectory>${project.build.testOutputDirectory}/opt/infinispan/bin</outputDirectory>
                                     <destFileName>server-runner</destFileName>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.infinispan</groupId>
+                                    <artifactId>infinispan-quarkus-cli</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>bin</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                                    <destFileName>ispn-cli</destFileName>
+                                </artifactItem>
                             </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>script-chmod</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>chmod</executable>
+                            <basedir>${project.build.testOutputDirectory}</basedir>
+                            <arguments>
+                                <argument>+x</argument>
+                                <argument>ispn-cli</argument>
+                            </arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/integration-tests/server/src/test/java/org/infinispan/quarkus/server/NativeCliIT.java
+++ b/integration-tests/server/src/test/java/org/infinispan/quarkus/server/NativeCliIT.java
@@ -1,0 +1,81 @@
+package org.infinispan.quarkus.server;
+
+import static org.infinispan.server.security.Common.sync;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.client.rest.RestCacheManagerClient;
+import org.infinispan.client.rest.RestClient;
+import org.infinispan.client.rest.RestResponse;
+import org.infinispan.server.test.junit4.InfinispanServerRule;
+import org.infinispan.server.test.junit4.InfinispanServerRuleBuilder;
+import org.infinispan.server.test.junit4.InfinispanServerTestMethodRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test to ensure that the native quarkus CLI is able to execute.
+ *
+ * @author Ryan Emerson
+ * @since 12.1
+ */
+public class NativeCliIT {
+   @ClassRule
+   public static final InfinispanServerRule SERVERS =
+         InfinispanServerRuleBuilder.config("configuration/ClusteredServerTest.xml")
+               .numServers(1)
+               .build();
+
+   @Rule
+   public InfinispanServerTestMethodRule SERVER_TEST = new InfinispanServerTestMethodRule(SERVERS);
+
+   @Test
+   public void testCliBatch() throws Exception {
+      RestClient client = SERVER_TEST.rest().create();
+      RestCacheManagerClient cm = client.cacheManager("default");
+      RestResponse restResponse = sync(cm.healthStatus());
+      assertEquals(200, restResponse.getStatus());
+      assertEquals("HEALTHY", restResponse.getBody());
+
+      String cliPath = resource("ispn-cli");
+      String batchFile = resource("batch.file");
+      String hostname = SERVERS.getTestServer().getDriver().getServerAddress(0).getHostAddress() + ":11222";
+      String cliCmd = String.format("%s --connect %s --file=%s", cliPath, hostname, batchFile);
+
+      ProcessBuilder pb = new ProcessBuilder("bash", "-c", cliCmd);
+      pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+      Process p = pb.start();
+      StringBuilder sb = new StringBuilder();
+      new Thread(() -> {
+         try (BufferedReader reader = new BufferedReader(new InputStreamReader(p.getErrorStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+               sb.append(line);
+            }
+         } catch (IOException e) {
+            throw new RuntimeException(e);
+         }
+      }).start();
+
+      p.waitFor(5, TimeUnit.SECONDS);
+      assertEquals(0, p.exitValue());
+      String stderr = sb.toString();
+      if (!stderr.isEmpty()) {
+         System.err.println(stderr);
+         fail("Unexpected CLI output in stderr");
+      }
+      restResponse = sync(client.cache("mybatch").exists());
+      assertEquals(200, restResponse.getStatus());
+   }
+
+   private String resource(String name) throws Exception {
+      return Paths.get(NativeCliIT.class.getClassLoader().getResource(name).toURI()).toString();
+   }
+}

--- a/integration-tests/server/src/test/resources/batch.file
+++ b/integration-tests/server/src/test/resources/batch.file
@@ -1,0 +1,1 @@
+create cache --template=org.infinispan.DIST_SYNC mybatch


### PR DESCRIPTION
- Could not instantiate class: class org.infinispan.cli.impl.ExitCodeResultHandler, no access to constructors
- Could not instantiate class: class org.infinispan.cli.commands.Batch, no access to constructors
- NativeCliIT added