### PR TITLE
Explicitly skip server-runner module during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish to OSSRH
-        run: ./mvnw -B deploy -Prelease -Pcommunity-release -DskipTests -Dmaven.javadoc.skip=true -P \!native -pl \!integration-tests/server
+        run: ./mvnw -B deploy -Prelease -Pcommunity-release -DskipTests -Dmaven.javadoc.skip=true -P \!native -pl \!integration-tests/server,\!server-runner
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
The `server-runner` module has the `skipNexusStagingDeployMojo` flag set. Unforutnately, the `nexus-staging-maven-plugin` defers the deploying of artifcats until the final module, which happens to be `server-runner` and consequently no artifacts are deployed.

https://stackoverflow.com/questions/25305850/how-to-disable-nexus-staging-maven-plugin-in-sub-modules#comment132699079_27557285

Skipping the `server-runner` entirely when deploying should workaround this issue.